### PR TITLE
Fixed issue when multiple HTML "a" tag "rel" attr values have to be used

### DIFF
--- a/class.zoom-social-icons-widget.php
+++ b/class.zoom-social-icons-widget.php
@@ -10410,10 +10410,11 @@ class Zoom_Social_Icons_Widget extends WP_Widget {
 			foreach ( $instance['fields'] as $field ) : ?>
 
 				<?php
-				$rule        = ( $instance['icon_style'] === 'with-canvas' ) ? 'background-color' : 'color';
-				$hover_style = empty( $field['color_picker_hover'] ) ? '' : 'data-hover-rule="' . $rule . '" data-hover-color="' . $field['color_picker_hover'] . '"'; ?>
+					$rule        = ( $instance['icon_style'] === 'with-canvas' ) ? 'background-color' : 'color';
+					$hover_style = empty( $field['color_picker_hover'] ) ? '' : 'data-hover-rule="' . $rule . '" data-hover-color="' . $field['color_picker_hover'] . '"';
+					$rel_tag = trim( $instance['no_follow'] === 'true' ? 'nofollow' : '' . $instance['no_opener'] === 'true' ? ' noopener' : '' . $instance['no_referrer'] === 'true' ? ' noreferrer' : ''); ?>
 				<li class="zoom-social_icons-list__item">
-					<a class="zoom-social_icons-list__link" href="<?php echo esc_url( $field['url'], $this->protocols ); ?>" <?php echo( $instance['open_new_tab'] === 'true' ? 'target="_blank"' : '' ); ?> <?php echo( $instance['no_follow'] === 'true' ? 'rel="nofollow"' : '' ); ?> <?php echo( $instance['no_opener'] === 'true' ? 'rel="noopener"' : '' ); ?> <?php echo( $instance['no_referrer'] === 'true' ? 'rel="noreferrer"' : '' ); ?>>
+					<a class="zoom-social_icons-list__link" href="<?php echo esc_url( $field['url'], $this->protocols ); ?>" <?php echo( $instance['open_new_tab'] === 'true' ? 'target="_blank"' : '' ); ?> <?php echo( strlen($rel_tag) > 0 ? 'rel="'.$rel_tag.'"' : '' ); ?>>
 						<?php if ( ! empty( $field['icon'] ) && ! empty( $field['icon_kit'] ) && ! empty( $field['color_picker'] ) ) {
 							$class = $field['icon_kit'] . ' ' . $field['icon_kit'] . '-' . $field['icon'];
 							$style = $rule . ' : ' . $field['color_picker'];


### PR DESCRIPTION
On one of my site, selecting multiple HTML "a" tag "rel" attribute values (noopener, noreferrer, nofollow) does not work (the rendered widget shows only one of them, usually "noopener").
SInce having multiple values for this attribute is valid, the fix make them show correctly.